### PR TITLE
feat: allow updating all pdf fields

### DIFF
--- a/tests/test_pdf_generation.py
+++ b/tests/test_pdf_generation.py
@@ -1,6 +1,6 @@
 import pathlib, sys
 sys.path.append(str(pathlib.Path(__file__).resolve().parent.parent))
-from generate_pdf import generate_pdf
+from generate_pdf import generate_pdf, _encode
 
 TEMPLATE_VALUES = (
     "18.08.2025 17:34:11 мск",
@@ -13,3 +13,37 @@ def test_recreate_template(tmp_path):
     out = tmp_path / "out.pdf"
     generate_pdf(*TEMPLATE_VALUES, out)
     assert out.read_bytes() == pathlib.Path("pdf 16.pdf").read_bytes()
+
+
+def _get_content(path: pathlib.Path) -> str:
+    import zlib
+
+    data = path.read_bytes()
+    start = data.index(b"9 0 obj")
+    stream_start = data.index(b"stream\r\n", start) + len(b"stream\r\n")
+    stream_end = data.index(b"\r\nendstream", stream_start)
+    comp = data[stream_start:stream_end]
+    return zlib.decompress(comp).decode("latin1")
+
+
+def test_custom_fields(tmp_path):
+    out = tmp_path / "out.pdf"
+    generate_pdf(
+        "01.01.2025 00:00 мск",
+        "OP123",
+        "ID456",
+        TEMPLATE_VALUES[3],
+        out,
+        form_date="02.02.2025 01:01 мск",
+        amount="1,23 RUR",
+        commission="1 RUR",
+        recipient="Иван Иванович ",
+        phone="79998887766",
+        bank="Банк",
+        account="111111",
+        message="Тест",
+    )
+    content = _get_content(out)
+    assert _encode("02.02.2025 01:01 мск") in content
+    assert _encode("1,23 RUR ") in content
+    assert _encode("Иван Иванович ") in content


### PR DESCRIPTION
## Summary
- allow overriding commission, recipient, account and other fields
- support extra CLI flags for setting all receipt values

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a867ec6370832f93b8f84d687e03ba