### PR TITLE
test: cover all dynamic pdf fields

### DIFF
--- a/generate_pdf.py
+++ b/generate_pdf.py
@@ -120,7 +120,10 @@ def generate_pdf(
     form_date: str = '22.08.2025 11:28 мск',
     amount: str = '0,01 RUR',
     commission: str = '0 RUR',
-    recipient: str = 'Михаил Сергеевич К',
+    # The recipient field in the template contains a trailing space
+    # before the line break. Keep the same default so regenerating the
+    # reference PDF does not rely on implicit padding logic.
+    recipient: str = 'Михаил Сергеевич К ',
     phone: str = '7й526247787',
     bank: str = 'В-Банк',
     account: str = '408178100088600й7530',

--- a/tests/test_pdf_generation.py
+++ b/tests/test_pdf_generation.py
@@ -28,16 +28,17 @@ def _get_content(path: pathlib.Path) -> str:
 
 def test_custom_fields(tmp_path):
     out = tmp_path / "out.pdf"
+    file_id = "1234567890abcdef1234567890abcdef"
     generate_pdf(
         "01.01.2025 00:00 мск",
         "OP123",
         "ID456",
-        TEMPLATE_VALUES[3],
+        file_id,
         out,
         form_date="02.02.2025 01:01 мск",
         amount="1,23 RUR",
         commission="1 RUR",
-        recipient="Иван Иванович ",
+        recipient="Иван Иванов ",
         phone="79998887766",
         bank="Банк",
         account="111111",
@@ -46,4 +47,16 @@ def test_custom_fields(tmp_path):
     content = _get_content(out)
     assert _encode("02.02.2025 01:01 мск") in content
     assert _encode("1,23 RUR ") in content
-    assert _encode("Иван Иванович ") in content
+    assert _encode("1 RUR ") in content
+    assert _encode("01.01.2025 00:00 мск ") in content
+    assert _encode("OP123 ") in content
+    assert _encode("Иван Иванов ") in content
+    assert _encode("79998887766") in content
+    assert _encode("Банк") in content
+    assert _encode("111111") in content
+    assert _encode("ID456") in content
+    assert _encode("Тест") in content
+    trailer = out.read_bytes()[-100:]
+    assert (
+        f"<{file_id}><{file_id}>".encode("ascii") in trailer
+    )


### PR DESCRIPTION
## Summary
- expand custom field test to ensure every dynamic field and trailer ID are replaceable
- align default recipient with template to keep trailing space

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a86d2f8d24832f985dec72708bad8b